### PR TITLE
Support vim-fugitive plugin's :Glog command

### DIFF
--- a/autoload/qfedit.vim
+++ b/autoload/qfedit.vim
@@ -42,6 +42,8 @@ function! qfedit#line(item) abort
   let fname = bufname(a:item.bufnr)
   if a:item.type ==# "\1"
     let fname = fnamemodify(fname, ':t')
+  elseif fname =~ "^fugitive://"
+    let fname = fnamemodify(fname, ':t')[0:6]
   endif
   return  (a:item.bufnr ? fname : '') . '|' .
         \ (a:item.lnum  ? a:item.lnum           : '') .

--- a/autoload/qfedit.vim
+++ b/autoload/qfedit.vim
@@ -42,7 +42,7 @@ function! qfedit#line(item) abort
   let fname = bufname(a:item.bufnr)
   if a:item.type ==# "\1"
     let fname = fnamemodify(fname, ':t')
-  elseif fname =~ "^fugitive://"
+  elseif fname =~# "^fugitive://"
     let fname = fnamemodify(fname, ':t')[0:6]
   endif
   return  (a:item.bufnr ? fname : '') . '|' .


### PR DESCRIPTION
With https://github.com/tpope/vim-fugitive plugin,
do `:Glog` command and switching the quickfix window (that shows `:Glog` result, or working git repo log history),
vim-qfedit plugin resets the quickfix window.

It is because of the difference between
the lines of quickfix window of `:Glog` command and bufname.

`b:qfedit_items` is like
`{'fugitive:///c/Users/xxxxxxxx/.vim/bundle/vim-qfedit/.git//fc59bd23c5f2d4a8843c237b3ab67dd06fd83c38|| bump up version to 0.4': ...`;

On the other hand, the line in the quickfix window is like `fc59bd2|| bump up version to 0.4`.

To correct this difference, modify obtained bufnames if it match `^fugitive://`.
