### PR TITLE
Bugfix: v8.2.3019 End Position Support

### DIFF
--- a/autoload/qfedit.vim
+++ b/autoload/qfedit.vim
@@ -45,7 +45,7 @@ function! qfedit#line(item) abort
   endif
   return ((a:item.bufnr ? fname : '') . '|' .
         \ (a:item.lnum ? a:item.lnum : '') .
-        \ (get(a:item, 'end_lnum') ? '-' . a:item.end_lnum : '') .
+        \ (get(a:item, 'end_lnum') && a:item.lnum != a:item.end_lnum ? '-' . a:item.end_lnum : '') .
         \ (a:item.col ? ' col ' . a:item.col .
         \ (get(a:item, 'end_col') && a:item.col != a:item.end_col ? '-' . a:item.end_col : '')
         \ : '') .


### PR DESCRIPTION
Do not add endline if the search result is one-line.
It had got result-line and item-key-name mismatch.

For example, for the line
`autoload/qfedit.vim|36 col 15-26| let items[qfedit#line(item)] = item`,
it tries to find list key
`autoload/qfedit.vim|36-36 col 15-26| let items[qfedit#line(item)] = item`,
with end line.

It results to find the entry and clear all the `vimgrep` result.