### PR TITLE
Keep existing lines on entering quick fix window

### DIFF
--- a/autoload/qfedit.vim
+++ b/autoload/qfedit.vim
@@ -50,7 +50,9 @@ function! qfedit#line(item) abort
         \ (get(a:item, 'end_col') && a:item.col != a:item.end_col ? '-' . a:item.end_col : '')
         \ : '') .
         \ qfedit#type(a:item.type, a:item.nr) . '| ' .
-        \ substitute(substitute(a:item.text, '\v^%(\t| )+', '', ''), '\v\n%(\n|\t| )*', ' ', 'g'))[:1023]
+        \ (a:item.valid ? substitute(substitute(a:item.text, '\v^%(\t| )+', '', ''), '\v\n%(\n|\t| )*', ' ', 'g')
+        \ : a:item.text)
+        \ )[:1023]
 endfunction
 
 function! qfedit#type(type, nr) abort


### PR DESCRIPTION
Invalid quick fix lines are removed on enterling quick fix window,
but the original lines should be left untouched.

```text
|| gcc a.c -o a
a.c|3 col 2| error: #error 1
||     3 | #error 1                             # These lines are removed
||       |  ^~~~~                               # on entering quick fix window
make: *** [Makefile|7| a] エラー 1
```

How to Repro
--------------------------------------------------------------------------------

Prepare the files below, and do Vim `:make` command.

```makefile
# makefile

# vim: ft=make noet ts=4 sts=4 sw=4

TARGET                   = a
SRCS                     = a.c

$(TARGET):              $(SRCS)
    $(CC) $^ -o $@
```

```c
// a.c

// vim: ft=c noet ts=4 sts=4 sw=4

#error 1

int main(int argc, char *argv[]) {
    return 0;
}
```
